### PR TITLE
unboom gremlin code and parse time from datetime

### DIFF
--- a/main.go
+++ b/main.go
@@ -168,7 +168,9 @@ func ParseEvent(rawJsonString string) (*EventWrapper, error) {
 		if err = json.Unmarshal([]byte(rawJsonString), msg); err != nil {
 			return nil, err
 		}
+
 		retval.WinEventMsg = msg
+
 	default:
 		if gVerbose {
 			fmt.Println("Unsupported event table:", retval.TableName)
@@ -243,7 +245,10 @@ func HandleEvent(evt *EventWrapper) {
 			IncludeEvent(evt.RawJsonStr, evt.EsProcessEventMsg.ToSimple())
 		}
 	case "windows_events":
-		if InSpecifiedTimeRangeSec(evt.WinEventMsg.UnixTime) {
+
+		t, _ := time.Parse(time.RFC3339, evt.WinEventMsg.Columns.DateTime)
+
+		if InSpecifiedTimeRangeSec(t.Unix()) {
 			if (evt.WinEventMsg.Columns.Eventid == "4688"){
 				IncludeEvent(evt.RawJsonStr, evt.WinEventMsg.ToSimple())
 			}

--- a/osquery_schema.go
+++ b/osquery_schema.go
@@ -56,10 +56,11 @@ PATH=-"
 type WinEventColumns struct {
 	Eventid string       `json:"eventid"`
 	Data string 			   `json:"data"`
+	DateTime string 		 `json:"datetime"`
 }
 
 type ProcessEventData struct {
-	ProcessEventData WinProcessData `json:"ProcessEventData"`
+	ProcessEventData WinProcessData `json:"EventData"`
 }
 
 type WinProcessData struct {
@@ -455,9 +456,12 @@ func (t *WinEvent) ToSimple() *types.SimpleEvent {
 	json.Unmarshal([]byte(t.Columns.Data), &data)
 	fields.Cmdline = data.ProcessEventData.CommandLine
 	fields.ExePath = data.ProcessEventData.ProcessName
-	fields.Pid, _ = strconv.ParseInt(string(data.ProcessEventData.NPid[2: len(data.ProcessEventData.NPid)]), 16, 64)
-	fields.ParentPid, _ = strconv.ParseInt(string(data.ProcessEventData.Pid[2: len(data.ProcessEventData.Pid)]),16, 64)
-
+	if len(data.ProcessEventData.NPid) > 2 {
+		fields.Pid, _ = strconv.ParseInt(string(data.ProcessEventData.NPid[2: len(data.ProcessEventData.NPid)]), 16, 64)
+	}
+	if len(data.ProcessEventData.Pid) > 2 {
+		fields.ParentPid, _ = strconv.ParseInt(string(data.ProcessEventData.Pid[2: len(data.ProcessEventData.Pid)]),16, 64)
+	}
 	ret.ProcessFields = fields
 	return ret
 }


### PR DESCRIPTION
```
{"evt_type":"P","ts":1685046336,"evt_process":{"cmdline":"harness.exe  --telemetrytoolpath ..\\telemetry-tool-example\\telemetry-tool-example.exe T1027#2","pid":19148,"parent_pid":20032,"exe_path":"D:\\atomic\\atomic-harness\\harness.exe","unique_pid":""}}
{"evt_type":"P","ts":1685046336,"evt_process":{"cmdline":"..\\telemetry-tool-example\\telemetry-tool-example.exe --prepare \"\"","pid":8660,"parent_pid":19148,"exe_path":"D:\\atomic\\telemetry-tool-example\\telemetry-tool-example.exe","unique_pid":""}}
{"evt_type":"P","ts":1685046336,"evt_process":{"cmdline":"D:\\atomic\\atomic-harness\\bin\\goartrun.exe --config .\\testruns\\harness-results-1741788712\\T1027_2_a50d5a97-2531-499e-a1de-5544c74432c6\\runspec.json","pid":21856,"parent_pid":19148,"exe_path":"D:\\atomic\\atomic-harness\\bin\\goartrun.exe","unique_pid":""}}
{"evt_type":"P","ts":1685046336,"evt_process":{"cmdline":"POWERSHELL -NoProfile C:\\Users\\admin\\AppData\\Local\\Temp\\artwork-T1027_2-3946868523\\goart-T1027-test.ps1","pid":8524,"parent_pid":21856,"exe_path":"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe","unique_pid":""}}
{"evt_type":"P","ts":1685046336,"evt_process":{"cmdline":"\"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe\" -EncodedCommand VwByAGkAdABlAC0ASABvAHMAdAAgACIASABlAHkALAAgAEEAdABvAG0AaQBjACEAIgA=","pid":23388,"parent_pid":8524,"exe_path":"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe","unique_pid":""}}
{"evt_type":"P","ts":1685046336,"evt_process":{"cmdline":"..\\telemetry-tool-example\\telemetry-tool-example.exe --fetch --resultsdir .\\testruns\\harness-results-1741788712 --ts 1685046292,1685046296","pid":10332,"parent_pid":19148,"exe_path":"D:\\atomic\\telemetry-tool-example\\telemetry-tool-example.exe","unique_pid":""}}
```

```
D:\atomic\atomic-harness>harness.exe --telemetrytoolpath ..\telemetry-tool-example\telemetry-tool-example.exe T1027#2
  prepare - nothing to do

Running test T1027 [2] a50d5a97-2531-499e-a1de-5544c74432c6 "Execute base64-encoded PowerShell"
D:\atomic\atomic-harness\bin\goartrun.exe --config .\testruns\harness-results-1741788712\T1027_2_a50d5a97-2531-499e-a1de-5544c74432c6\runspec.json
runner exited with code 9 TestRan
launching  ..\telemetry-tool-example\telemetry-tool-example.exe --fetch --resultsdir .\testruns\harness-results-1741788712 --ts 1685046292,1685046296
telemetry tool exit code: 14 Ready2Eval
Done. Output in .\testruns\harness-results-1741788712
-    T1027  2 Done NoTelemetry  <P><P><P><P>     "Execute base64-encoded PowerShell"
=== Validated:0 Partial:0 NoTelemetry:1 Skipped:0 RunErrors:0 MissingDeps:0 NoTests:0
```